### PR TITLE
Add mocked data for comic 404

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -215,12 +215,15 @@ class Bot():
     def find_comic(self, number):
         """
         Finds the json data of the comic with the given number.
+        Returns a specially constructed json object for comic 404.
         Returns none if there is no comic with the given number.
         """
         url = f"http://xkcd.com/{number}/info.0.json"
         response = requests.get(url)
 
-        if response.status_code == 404:
+        if number == 404:
+            return {"title": "Not Found", "alt": "", "img": "https://www.explainxkcd.com/wiki/images/9/92/not_found.png", "num": 404}
+        elif response.status_code == 404:
             return None
         elif response is None:
             return None


### PR DESCRIPTION
If comic number is 404, return a mocked JSON object instead of None.

Comic name: "Not Found" (as titled by Explainxkcd)
Alt text: Blank
Image: Picture of the 404 screen from Explainxkcd