### PR TITLE
Increase specificity of regex matching

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -199,14 +199,18 @@ class Bot():
          - If using non-strict matching, all tokens are valid
         """
         if strict_match:
-            matches = re.findall(r"""(?i)(?x)       # Ignore case, comment mode
-                                (?<= ! | \# )       # Must be preceded by an exclamation mark or a pound sign    
-                                {}                  # Matches the following token
+            matches = re.findall(r"""(?i)(?x)           # Ignore case, comment mode
+                                (?<= ^! | \s! | \(!     # Must be preceded by whitespace, line start, or open paren
+                                    ^\# | \s\# | \(! )  # and an exlaimation mark or pound sign
+                                {}                      # Match token
+                                (?= \b )                # Match only on a word boundary
                                 """.format(token), body)
+
         else:
-            matches = re.findall(r"""(?i)(?x)       # Ignore case, comment mode
-                                {}                  # Matches the following token
-                                """.format(token),  body)
+            matches = re.findall(r"""(?i)(?x)       # Ignore case, comment mode   
+                                {}                  # Match token
+                                """.format(token), body)
+
         return matches
 
     def match_numbers(self, body, strict_match):
@@ -232,7 +236,7 @@ class Bot():
 
             return unique_numbers
 
-        numbers = self.match_token('\d+', body, strict_match)
+        numbers = self.match_token('\d{1,4}', body, strict_match)
         stripped_numbers = strip_leading_zeroes(numbers)
         if self.match_latest(body, strict_match):
             stripped_numbers.append(self.get_latest_comic())

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -30,10 +30,24 @@ class TestBot(unittest.TestCase):
 
     def test_match_numbers_strict(self):
         self.assertEqual(self.bot.match_numbers("Test", True), [])
+        self.assertEqual(self.bot.match_numbers("!Test !001234 5678 !-1", True), [])
+
         self.assertEqual(self.bot.match_numbers("!123 !123", True), ["123"])
         self.assertEqual(self.bot.match_numbers("7? !080. !99", True), ["80", "99"])
         self.assertEqual(self.bot.match_numbers("!900 10000", True), ["900"])
-        self.assertEqual(self.bot.match_numbers("!Test !001234 5678 !-1", True), ["1234"])
+
+        self.assertEqual(self.bot.match_numbers("!1234", true), ["1234"])
+        self.assertEqual(self.bot.match_numbers("#1234", true), ["1234"])
+        self.assertEqual(self.bot.match_numbers("Let's look at !1234", true), ["1234"])
+        self.assertEqual(self.bot.match_numbers("Let's look at #1234.", true), ["1234"])
+        self.assertEqual(self.bot.match_numbers("some text (!1234) some more", true), ["1234"])
+
+        self.assertEqual(self.bot.match_numbers()"I spent $123.45 today", true), [])
+        self.assertEqual(self.bot.match_numbers()"Comic #12345 doesn't exist", true), [])
+        self.assertEqual(self.bot.match_numbers()"website.com/?=!1234", true), [])
+        self.assertEqual(self.bot.match_numbers()"website.com/?=#1234", true), [])
+        self.assertEqual(self.bot.match_numbers()"I have made a mistake referencing this xkcd#1234", true), [])
+        self.assertEqual(self.bot.match_numbers()"some junk -> a^698f7%s@ !123a*b@3", true), [])
 
     def test_find_numbers_non_strict(self):
         self.assertEqual(self.bot.match_numbers("Test", False), [])


### PR DESCRIPTION
(?<= ^! | \s! | \(! ^\# | \s\# | \(! )
    This ensures that there is a white space or open parenthesis before the code character.
    It makes sure the match only happens if the pattern isn't embedded inside other text (or is in parentheses).

\d{1,4}
    This ensures that we only match if the number after the bang is 1 to 4 digits long. If Randall keeps updating weekly, it will take about 148 years before we reach a comic #10000. Limiting the number of digits being matched will greatly reduce false negatives.

(?= \b )
    This ensures that the end of the match is only on a word boundary. This allows for punctuation, whitespace, etc. But will prevent matching on accidental junk like !123&adf8 or whatever.


The regex in this PR matches correctly on the following:
    !1234
    #1234
    Let's look at !1234
    Let's look at #1234.
    ...looking at the comic in question (!1234) we can say that...

But not:
    I spent $123.45 today
    Comic #12345 doesn't exist
    website.com/?=!1234
    website.com/?=#1234
    I have made a mistake referencing this xkcd#1234
    some junk -> a^698f7%s@ !123a*b@3