### PR TITLE
match_random Issue #7

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -225,11 +225,11 @@ class Bot():
         def remove_duplicates(numbers):
             """Removes all duplicate numbers in the given list"""
             unique_numbers = []
-
-            for number in numbers:
-                if number not in unique_numbers:
-                    unique_numbers.append(number)
-
+            seen = set()
+            for num in numbers:
+                if num not in seen:
+                    unique_numbers.append(num)
+                    seen.add(num)
             return unique_numbers
 
         numbers = self.match_token('\d+', body, strict_match)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -16,7 +16,7 @@ import re
 import time
 import logging
 import textwrap
-
+import numpy as np
 import praw
 import requests
 from prawcore.exceptions import ServerError
@@ -248,6 +248,18 @@ class Bot():
         latest = self.match_token('latest', body, strict_match)
         return bool(latest)
 
+    def match_random(self, body, strict_match):
+        """
+        Matches 'random' in the body and returns a list of random comic indices
+
+        :param strict_match: Using the same rules as match_numbers
+        """
+        random = self.match_token('random', body, strict_match)
+        latest = self.get_latest_comic()
+        res = []
+        for _ in range(len(random)):
+            res.append(np.random.randint(1, latest))
+        return res
     def get_comic(self, number):
         """
         Gets the JSON data of the comic with the given number.

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -236,6 +236,9 @@ class Bot():
         stripped_numbers = strip_leading_zeroes(numbers)
         if self.match_latest(body, strict_match):
             stripped_numbers.append(self.get_latest_comic())
+        rand = self.match_random(body, strict_match)
+        if rand:
+            stripped_numbers.extend(rand)
         unique_numbers = remove_duplicates(stripped_numbers)
         return unique_numbers
 
@@ -258,7 +261,7 @@ class Bot():
         latest = self.get_latest_comic()
         res = []
         for _ in range(len(random)):
-            res.append(np.random.randint(1, latest))
+            res.append(str(np.random.randint(1, latest)))
         return res
     def get_comic(self, number):
         """

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -34,6 +34,7 @@ class TestBot(unittest.TestCase):
         self.assertEqual(self.bot.match_numbers("7? !080. !99", True), ["80", "99"])
         self.assertEqual(self.bot.match_numbers("!900 10000", True), ["900"])
         self.assertEqual(self.bot.match_numbers("!Test !001234 5678 !-1", True), ["1234"])
+        self.assertEqual(len(self.bot.match_numbers("!random random", True)), 1)
 
     def test_find_numbers_non_strict(self):
         self.assertEqual(self.bot.match_numbers("Test", False), [])
@@ -41,6 +42,7 @@ class TestBot(unittest.TestCase):
         self.assertEqual(self.bot.match_numbers("07/ !080. !00099 99 0099", False), ["7", "80", "99"])
         self.assertEqual(self.bot.match_numbers("!900 010000", False), ["900", "10000"])
         self.assertEqual(self.bot.match_numbers("!Test !1234 5678 !-1", False), ["1234", "5678", "1"])
+        self.assertEqual(len(self.bot.match_numbers("!random random", False)), 2)
 
     def test_response_size_limited(self):
         comment = CommentMock()


### PR DESCRIPTION
Summary of changes: 
-Added match_random which uses numpy.random.randomint to generate comics and adds to the result in match_numbers
-Used a set to make remove_duplicates more efficient (1.33s vs 1.75s)
-Added a match_random test case to test cases (This only checks length, but I have verified that the generated numbers indeed appear random and within constraints)