### PR TITLE
Bot no longer crashes if one message throws an error

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -77,7 +77,13 @@ class Bot():
         for item in stream:
             if item is None:
                 break
-            callback(item)
+
+            # Just a try/except to stop the bot from crashing if one message throws an error
+            try:
+                callback(item)
+            except:
+                logger.error(f"Error while handling message item!")
+            
         time.sleep(sleep_time)
         
 


### PR DESCRIPTION
Sort of addresses issue #1, bot will no longer completely crash if one message causes an error.