### PR TITLE
Implementation of Issue #6

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -79,13 +79,12 @@ class Bot():
                 break
 
             # Just a try/except to stop the bot from crashing if one message throws an error
-            try:
-                callback(item)
-            except:
-                logger.error(f"Error while handling message item!")
+            # try:
+            callback(item)
+            # except:
+                # logger.error(f"Error while handling message item!")
             
         time.sleep(sleep_time)
-        
 
     def authenticate(self):
         """Authenticates a reddit user with the credentials from the configuration file."""
@@ -243,7 +242,31 @@ class Bot():
                     seen.add(num)
             return unique_numbers
 
+        def get_range_numbers(body, strict_match):
+            """Matches all comic id ranges and returns a list of all the numbers in those ranges."""
+            ranges = self.match_token(r"\d+\.{3}\d+", body, strict_match)
+
+            ret = []
+            for range_ in ranges:
+                nums = re.findall(r"\d+", range_)
+
+                if nums[0] >= nums[1]:
+                    lo = nums[1]
+                    hi = nums[0]
+                else:
+                    lo = nums[0]
+                    hi = nums[1]
+
+                lo = int(lo)
+                hi = int(hi)
+
+                for i in range(lo, hi+1):
+                    ret.append(str(i))
+            
+            return ret
+
         numbers = self.match_token(r"\d+", body, strict_match)
+        numbers.extend(get_range_numbers(body, strict_match))
         stripped_numbers = strip_leading_zeroes(numbers)
 
         if self.match_latest(body, strict_match):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -79,10 +79,10 @@ class Bot():
                 break
 
             # Just a try/except to stop the bot from crashing if one message throws an error
-            # try:
-            callback(item)
-            # except:
-                # logger.error(f"Error while handling message item!")
+            try:
+                callback(item)
+            except:
+                logger.error(f"Error while handling message item!")
             
         time.sleep(sleep_time)
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -35,6 +35,7 @@ class TestBot(unittest.TestCase):
         self.assertEqual(self.bot.match_numbers("!900 10000", True), ["900"])
         self.assertEqual(self.bot.match_numbers("!Test !001234 5678 !-1", True), ["1234"])
         self.assertEqual(len(self.bot.match_numbers("!random random", True)), 1)
+        self.assertEqual(self.bot.match_numbers("!9 !23...25 #9...7", True), ["9", "23", "24", "25", "7", "8"])
 
     def test_find_numbers_non_strict(self):
         self.assertEqual(self.bot.match_numbers("Test", False), [])
@@ -43,6 +44,7 @@ class TestBot(unittest.TestCase):
         self.assertEqual(self.bot.match_numbers("!900 010000", False), ["900", "10000"])
         self.assertEqual(self.bot.match_numbers("!Test !1234 5678 !-1", False), ["1234", "5678", "1"])
         self.assertEqual(len(self.bot.match_numbers("!random random", False)), 2)
+        self.assertEqual(self.bot.match_numbers("9 23...25 9...7", False), ["9", "23", "25", "7", "24", "8"])
 
     def test_response_size_limited(self):
         comment = CommentMock()


### PR DESCRIPTION
I tested it and it seems to work fine. Backwards ranges work the same way as normal ones (low to high id). The current implementation of numbers, ranges and titles matching is causing comics to appear in a weird order though. Don't know if we really care about the order they appear in but it could certainly look better.

We could sort the comic ids in ascending order but they would not appear in the order the user requests them. Otherwise we could find a better way to match numbers, ranges and titles so they don't mix.