### PR TITLE
Implementation of "Call bot with relevant xkcd: {}"

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -79,8 +79,8 @@ class Bot():
                 break
             try:
                 callback(item)
-            except:
-                logger.error(f"Error while handling message item!")
+            except Exception as e:
+                logger.error(f"Caught exception '{e}' while handling message item!")
             
         time.sleep(sleep_time)
         
@@ -212,6 +212,10 @@ class Bot():
                                 (?<= ! | \# )       # Must be preceded by an exclamation mark or a pound sign    
                                 {}                  # Matches the following token
                                 """.format(token), body)
+            matches.extend(re.findall(r"""(?i)(?x)
+                                (?<= relevant[ ]xkcd:[ ])
+                                {}
+                                """.format(token), body))
         else:
             matches = re.findall(r"""(?i)(?x)       # Ignore case, comment mode
                                 {}                  # Matches the following token

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -35,6 +35,7 @@ class TestBot(unittest.TestCase):
         self.assertEqual(self.bot.match_numbers("!900 10000", True), ["900"])
         self.assertEqual(self.bot.match_numbers("!Test !001234 5678 !-1", True), ["1234"])
         self.assertEqual(len(self.bot.match_numbers("!random random", True)), 1)
+        self.assertEqual(self.bot.match_numbers("!3 relevant xkcd: 6, !relevant xkcd: 5 1", True), ["3", "6", "5"])
 
     def test_find_numbers_non_strict(self):
         self.assertEqual(self.bot.match_numbers("Test", False), [])
@@ -43,6 +44,7 @@ class TestBot(unittest.TestCase):
         self.assertEqual(self.bot.match_numbers("!900 010000", False), ["900", "10000"])
         self.assertEqual(self.bot.match_numbers("!Test !1234 5678 !-1", False), ["1234", "5678", "1"])
         self.assertEqual(len(self.bot.match_numbers("!random random", False)), 2)
+        self.assertEqual(self.bot.match_numbers("!3 relevant xkcd: 6, !relevant xkcd: 5 1", False), ["3", "6", "5", "1"])
 
     def test_response_size_limited(self):
         comment = CommentMock()


### PR DESCRIPTION
I added code in function **match_token** so it also matches numbers that are preceded by "relevant xkcd: ". This is only needed when **strict_match** is set to **True** since when it is **False**, the number will be matched anyway. A few tests are included as well.

I also modified the try/catch block to display a better message when an error occurs, so we can have a better idea of what went wrong.