### PR TITLE
Truncation of comment body and changes to matching of comic numbers

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -103,15 +103,14 @@ class Bot():
             return
 
         comment_id = comment.id
-        body = comment.body
+        body = comment.body[:5_000]
         comic_ids = self.match_numbers(body, strict_match)
         comic_titles = self.match_titles(body)
         responses = []
 
         for comic_id in comic_ids:
             if len(responses) > RESPONSE_COUNT_LIMIT:
-                logger.warning(
-                    f"Exceeded the reponse count limit of {RESPONSE_COUNT_LIMIT} responses")
+                logger.warning(f"Exceeded the reponse count limit of {RESPONSE_COUNT_LIMIT} responses")
                 break
 
             comic = self.get_comic(comic_id)
@@ -126,8 +125,7 @@ class Bot():
         seen = set()
         for comic_title in comic_titles:
             if len(responses) > RESPONSE_COUNT_LIMIT:
-                logger.warning(
-                    f"Exceeded the reponse count limit of {RESPONSE_COUNT_LIMIT} responses")
+                logger.warning(f"Exceeded the reponse count limit of {RESPONSE_COUNT_LIMIT} responses")
                 break
 
             comic = self.get_comic_by_title(comic_title)
@@ -267,7 +265,7 @@ class Bot():
 
         def get_range_numbers(body, strict_match):
             """Matches all comic id ranges and returns a list of all the numbers in those ranges."""
-            ranges = self.match_token(r"\d+\.{3}\d+", body, strict_match)
+            ranges = self.match_token(r"\d{1,6}\.{3}\d{1,6}", body, strict_match)
 
             ret = []
             for range_ in ranges:
@@ -288,7 +286,7 @@ class Bot():
             
             return ret
 
-        numbers = self.match_token(r"\d+", body, strict_match)
+        numbers = self.match_token(r"\d{1,6}", body, strict_match)
         numbers.extend(get_range_numbers(body, strict_match))
         stripped_numbers = strip_leading_zeroes(numbers)
 


### PR DESCRIPTION
As discussed in #1, the bot should only handle up to a certain amount of characters to prevent any kind of overload.

Also, since as of today the number of xkcd comics is less than 2500, the regex shouldn't match any ridiculously large numbers as that could cause issues for no reason.

So in order to address these two issues, I truncated the body's length to 5000 and I changed the regex so it will only match numbers up to 6 digits long. Which should be more than enough and it's also a fairly small number for Python to handle.