### PR TITLE
Issue #1 fix

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -161,7 +161,7 @@ class Database():
             self.connection.commit()
 
     def get_comic_number(self, comic_title):
-        """Returns number of comic with given title if it exists, otherwise returns None."""
+        """Returns number (int) of comic with given title if it exists, otherwise returns None."""
         sql = f"""
                 SELECT number
                 FROM {comic_titles_table}

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -3,7 +3,6 @@ import textwrap
 
 from bot.bot import Bot, RESPONSE_CHAR_LIMIT, RESPONSE_COUNT_LIMIT
 
-
 class CommentMock:
     def __init__(self):
         self.reply_called = 0
@@ -18,6 +17,7 @@ class CommentMock:
 
 class TestBot(unittest.TestCase):
     def setUp(self):
+        self.maxDiff = None
         self.bot = Bot("./cfg/test_config.json", "test", ":memory:")
 
     def test_get_comic(self):
@@ -31,40 +31,40 @@ class TestBot(unittest.TestCase):
 
     def test_match_numbers_strict(self):
         self.assertEqual(self.bot.match_numbers("Test", True), [])
-        self.assertEqual(self.bot.match_numbers("!123 !123", True), ["123"])
+        self.assertEqual(self.bot.match_numbers("!123 !123", True), [123])
         self.assertEqual(self.bot.match_numbers(
-            "7? !080. !99", True), ["80", "99"])
-        self.assertEqual(self.bot.match_numbers("!900 10000", True), ["900"])
+            "7? !080. !99", True), [80, 99])
+        self.assertEqual(self.bot.match_numbers("!900 10000", True), [900])
         self.assertEqual(self.bot.match_numbers(
-            "!Test !001234 5678 !-1", True), ["1234"])
+            "!Test !001234 5678 !-1", True), [1234])
         self.assertEqual(
             len(self.bot.match_numbers("!random random", True)), 1)
         self.assertEqual(self.bot.match_numbers(
-            "!3 relevant xkcd: 6, !relevant xkcd: 5 1", True), ["3", "6", "5"])
+            "!3 relevant xkcd: 6, !relevant xkcd: 5 1", True), [3, 6, 5])
         self.assertEqual(self.bot.match_numbers("!9 !23...25 #9...7", True), [
-                         "9", "23", "24", "25", "7", "8"])
+                         9, 23, 24, 25, 7, 8])
         self.assertEqual(self.bot.match_numbers("https://www.google.com/maps/dir/Okay,+Oklahoma,+USA/Whynot,+North+Carolina+27341,+USA/@35.283469,-92.0617932,6z/data=!3m1!4b1!4m14!4m13!1m5!1m1!1s0x87b60bd75e51d2d3:0x120194060a920373!2m2!1d-95.3182985!2d35.8506548!1m5!1m1!1s0x8853609903e1db5b:0x15b011f26e28c49e!2m2!1d-79.7480465!2d35.5402827!3e0", True), [])
         self.assertEqual(self.bot.match_numbers(
             "number is mid!1string", True), [])
         self.assertEqual(self.bot.match_numbers(
-            "!12 hello https://www.google.com/!1", True), ["12"])
-        self.assertEqual(self.bot.match_numbers("#1mid#6number", True), ["1"])
+            "!12 hello https://www.google.com/!1", True), [12])
+        self.assertEqual(self.bot.match_numbers("#1mid#6number", True), [1])
 
-    def test_find_numbers_non_strict(self):
+    def test_match_numbers_non_strict(self):
         self.assertEqual(self.bot.match_numbers("Test", False), [])
-        self.assertEqual(self.bot.match_numbers("!123.", False), ["123"])
+        self.assertEqual(self.bot.match_numbers("!123.", False), [123])
         self.assertEqual(self.bot.match_numbers(
-            "07/ !080. !00099 99 0099", False), ["7", "80", "99"])
+            "07/ !080. !00099 99 0099", False), [7, 80, 99])
         self.assertEqual(self.bot.match_numbers(
-            "!900 010000", False), ["900", "10000"])
+            "!900 010000", False), [900, 10000])
         self.assertEqual(self.bot.match_numbers(
-            "!Test !1234 5678 !-1", False), ["1234", "5678", "1"])
+            "!Test !1234 5678 !-1", False), [1234, 5678, 1])
         self.assertEqual(
             len(self.bot.match_numbers("!random random", False)), 2)
         self.assertEqual(self.bot.match_numbers(
-            "!3 relevant xkcd: 6, !relevant xkcd: 5 1", False), ["3", "6", "5", "1"])
+            "!3 relevant xkcd: 6, !relevant xkcd: 5 1", False), [3, 6, 5, 1])
         self.assertEqual(self.bot.match_numbers("9 23...25 9...7", False), [
-                         "9", "23", "25", "7", "24", "8"])
+                         9, 23, 25, 7, 24, 8])
 
     def test_response_size_limited(self):
         comment = CommentMock()


### PR DESCRIPTION
<strong>Issue reproduction / explanation:</strong>
1. User enters very large comic number (i.e. many digits)
2. The bot requests comic from xkcd.com
3. xkcd.com returns [503](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) response because of large url
4. `response` is not None and neither is `response.status_code` 404, so the bot falsely assumes response contains json data
5. The bot tries to access json data and an exception is thrown on statement `config = response.json()`
6. Exception is caught by `try/except` block and execution continues so the comment is basically skipped

(note that as of lately I wasn't able to reproduce the issue. xkcd.com seems to return 404 now even when the url is very large, but this could be temporary. Nevertheless, these changes should help avoid any issues with other status codes that might be returned.)
</br>

<strong>Changes:</strong>
1. Truncated comment body down to 10k characters
 (this is not the cause of the issue but it could solve similar problems)

2. Modified `if/else` block that checked for a None or 404 response to now check for None, or !200 before accessing json data
This way `config = response.json()` will only be run when response is 200

3. Modified the functions that match comic ids to only return integers.
This way `comic_ids` will only contain integers.
</br>

I'm still testing and looking into any changes that need to be done to the test cases.